### PR TITLE
docker-compose.yml and run.sh for dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-*
 !target/*-runner
 !target/*-runner.jar
 !target/lib/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ docker run -d --name mariadb-db -p 3306:3306 -e MYSQL_USER=maria -e MYSQL_ROOT_P
 ```bash
 ./mvnw compile quarkus:dev
 ```
-3. From a browser access http://localhost:8080/swagger-ui and the test:
+3. Or you can run inside docker-compose:
+```
+chmod +x ./run.sh
+./run.sh
+```
+4. From a browser access http://localhost:8080/swagger-ui and the test:
    - /users/list - select data from the PostgreSQL;
    - /orders/list - select data from the MariaDB (or Oracle database);
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+mvn package
+docker-compose -f ./src/main/docker/docker-compose.yml up --build

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #/bin/bash
-mvn package
+
 docker-compose -f ./src/main/docker/docker-compose.yml up --build

--- a/src/main/docker/Dockerfile.dev
+++ b/src/main/docker/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM maven:3.6.3-jdk-11-slim
+ENV MVNW_VERBOSE=true
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n"
+ENV AB_ENABLED=jmx_exporter
+
+WORKDIR /app
+COPY . .
+RUN  mvn package
+
+CMD ["/bin/bash", "-c", "/app/mvnw compile quarkus:dev"]

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -3,12 +3,14 @@ services:
   poc-quarkus-multiple-datasources:
     build:
       context: ../../../
-      dockerfile: ./src/main/docker/Dockerfile.jvm
+      dockerfile: ./src/main/docker/Dockerfile.dev
     environment:
       - POSTGRESQL_SERVICE_HOST=postgresql
       - POSTGRESQL_SERVICE_PORT=5432
       - MARIADB_SERVICE_HOST=mariadb
-      - MARIA_SERVICE_PORT=3306      
+      - MARIA_SERVICE_PORT=3306
+    ports:
+      - 8080:8080
     networks:
       - poc-net
     depends_on:

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.8"
+services:
+  poc-quarkus-multiple-datasources:
+    build:
+      context: ../../../
+      dockerfile: ./src/main/docker/Dockerfile.jvm
+    environment:
+      - POSTGRESQL_SERVICE_HOST=postgresql
+      - POSTGRESQL_SERVICE_PORT=5432
+      - MARIADB_SERVICE_HOST=mariadb
+      - MARIA_SERVICE_PORT=3306      
+    networks:
+      - poc-net
+    depends_on:
+      - postgresql
+      - mariadb
+      
+
+  postgresql:
+    image: postgres
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=usersdb
+      - POSTGRES_USER=postgres
+    ports:
+        - 5432:5432
+    networks:
+      - poc-net
+
+        
+  mariadb:
+    image: mariadb
+    environment:
+      - MYSQL_DATABASE=ordersdb
+      - MYSQL_PASSWORD=maria
+      - MYSQL_ROOT_PASSWORD=maria
+      - MYSQL_USER=maria
+    ports:
+        - 3306:3306
+    networks:
+      - poc-net
+
+
+networks:
+  poc-net:
+    driver: bridge


### PR DESCRIPTION
@felipewind,

- docker-compose.yml, with two SGBDs and build the Quarkus application;
- run.sh, to executes with a single command;
- Dockerfile.dev, to compile and run Quarkus application in dev mode

For issue:
https://github.com/felipewind/poc-quarkus-multiple-datasources/issues/3